### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Use secure copyright file specification URI.
+  * Update renamed lintian tag names in lintian overrides.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Use secure copyright file specification URI.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Use secure copyright file specification URI.
   * Update renamed lintian tag names in lintian overrides.
+  * Set upstream metadata fields: Repository, Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
   * Use secure copyright file specification URI.
   * Update renamed lintian tag names in lintian overrides.
   * Set upstream metadata fields: Repository, Repository-Browse.
+  * Fix day-of-week for changelog entry 2.0.1-1.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
 
@@ -224,7 +225,7 @@ obconf (2.0.1-1) unstable; urgency=low
   * Remove unused dpatch stuff.
   * Add menu file.
 
- -- Anibal Avelar (Fixxxer) <aavelar@cofradia.org>  Sun, 15 Jun 2007 23:44:05 +0200
+ -- Anibal Avelar (Fixxxer) <aavelar@cofradia.org>  Fri, 15 Jun 2007 23:44:05 +0200
 
 obconf (1.6-1) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
+
 obconf (1:2.0.4+git20150213-2) unstable; urgency=medium
 
   * debian/control:

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: x11
 Priority: optional
 Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
 Build-Depends:
- debhelper (>= 10), autopoint, gettext, libgtk-3-dev, 
+ debhelper (>= 10), autopoint, gettext, libgtk-3-dev,
  libimlib2-dev, libsm-dev, libstartup-notification0-dev,
  libcairo2-dev, openbox-dev (>= 3.6.1-3~)
 Standards-Version: 3.9.8

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ObConf
 Upstream-Contact: openbox@icculus.org
 Source: http://www.openbox.org/dist/obconf/

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,1 +1,1 @@
-debian-watch-may-check-gpg-signature
+debian-watch-does-not-check-gpg-signature

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+Repository: https://github.com/danakj/obconf.git
+Repository-Browse: https://github.com/danakj/obconf


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri.html))
* Update renamed lintian tag names in lintian overrides. ([renamed-tag](https://lintian.debian.org/tags/renamed-tag.html))
* Set upstream metadata fields: Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Fix day-of-week for changelog entry 2.0.1-1. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/obconf/b9554740-73fd-4744-956c-815cfdf24288.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/b9554740-73fd-4744-956c-815cfdf24288/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b9554740-73fd-4744-956c-815cfdf24288/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b9554740-73fd-4744-956c-815cfdf24288/diffoscope)).
