### PR TITLE
Bump debhelper dependency to >= 10, since that's what is used in debian/compat

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,8 @@ obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
   * Fix day-of-week for changelog entry 2.0.1-1.
   * Remove constraints unnecessary since stretch:
     + Build-Depends: Drop versioned constraint on debhelper.
+  * Bump debhelper dependency to >= 10, since that's what is used in
+    debian/compat.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: x11
 Priority: optional
 Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
 Build-Depends:
- debhelper, autopoint, gettext, libgtk-3-dev,
+ debhelper (>= 10~), autopoint, gettext, libgtk-3-dev,
  libimlib2-dev, libsm-dev, libstartup-notification0-dev,
  libcairo2-dev, openbox-dev (>= 3.6.1-3~)
 Standards-Version: 3.9.8


### PR DESCRIPTION

Bump debhelper dependency to >= 10, since that's what is used in debian/compat. ([package-lacks-versioned-build-depends-on-debhelper](https://lintian.debian.org/tags/package-lacks-versioned-build-depends-on-debhelper))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/obconf/edbfe770-7470-411d-ab19-2cfc867985ee.
