### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,8 @@ obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
     + Build-Depends: Drop versioned constraint on debhelper.
   * Bump debhelper dependency to >= 10, since that's what is used in
     debian/compat.
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on openbox-dev.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
 Build-Depends:
  debhelper (>= 10~), autopoint, gettext, libgtk-3-dev,
  libimlib2-dev, libsm-dev, libstartup-notification0-dev,
- libcairo2-dev, openbox-dev (>= 3.6.1-3~)
+ libcairo2-dev, openbox-dev
 Standards-Version: 3.9.8
 Homepage: https://github.com/danakj/obconf
 Vcs-Browser: https://github.com/mati75/obconf-debian.git


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/obconf/13285f37-a42e-4f68-a9ae-1aa6be09c225.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package obconf: lines which differ (wdiff format)
* Depends: libc6 (>= 2.33), libcairo2 (>= 1.2.4), libgdk-pixbuf-2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.35.9), libgtk-3-0 (>= 3.0.0), libobrender32v5 (>= [-3.6.1-3~),-] {+3.6.0),+} libobt2v5 (>= [-3.6.1-3~),-] {+3.6.0),+} libstartup-notification0 (>= 0.2), libx11-6, libxml2 (>= 2.7.4)

No differences were encountered between the control files of package \*\*obconf-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/13285f37-a42e-4f68-a9ae-1aa6be09c225/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/13285f37-a42e-4f68-a9ae-1aa6be09c225/diffoscope)).
