### PR TITLE
Do not ship the old KDE MIMEs (#875517)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,10 @@ obconf (1:2.0.4+git20150213-3) UNRELEASED; urgency=medium
   * Remove constraints unnecessary since buster:
     + Build-Depends: Drop versioned constraint on openbox-dev.
 
+  [ Pino Toscano ]
+  * Stop shipping the old KDE desktop MIME types, as they are no more needed
+    now. (Closes: #875517)
+
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 01:23:07 +0000
 
 obconf (1:2.0.4+git20150213-2) unstable; urgency=medium

--- a/debian/rules
+++ b/debian/rules
@@ -4,3 +4,8 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
 	dh ${@}
+
+override_dh_auto_install:
+	dh_auto_install
+	# drop old KDE desktop MIMEs
+	rm -rfv debian/obconf/usr/share/mimelnk/


### PR DESCRIPTION
Strictly speaking, I created a PR to the upstream repository for this:
https://github.com/danakj/obconf/pull/10
there were no updates there in the last 7 years though, so I doubt that that PR will be picked any time soon; hence, let's cleanup at least Debian (and derivatives).